### PR TITLE
[do not merge] adding initializing context for workflow json/yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,34 @@ This api also provides the Service Providers for the three interfaces, namely:
 WorkflowManager manager = WorkflowManagerProvider.getInstance().get();
 ...
 ```
+### Support for workflow initializing context
+Sometimes you don't want to hard-code all values in your
+workflow json/yaml but want to use existing properties or object values
+for some defaults, or often used settings.
+This can promote reusability and ease maintenance of multiple workflows.
 
+This project provides support for initializing your workflow values from properties. 
+These properties can come from different sources such as properties file, map, string, or inputstream.
+
+You can use these properties in your workflow json/yaml for string, enum values (number and boolean not support atm).
+To use them your value must start with a "$$" and specify a json path expression.
+
+For example if we had an application.properties file in our app with value:
+
+```
+my.workflow.default.name=defaultName
+```
+you can access this value in your workflow json with:
+
+```json
+{
+    "name": "$$.my.workflow.default.name",
+    "states": []
+}
+```
+
+Implementors must assure that the InitializingContext class provided here is set up 
+and passed to the WorkflowObjectMapper in their implementations for
+this feature to be enabled.
 
 ### More to come soon!

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
     <slf4j.version>1.7.28</slf4j.version>
     <commons-jexl3.version>3.1</commons-jexl3.version>
     <spel.version>5.1.9.RELEASE</spel.version>
+    <json.path.version>2.4.0</json.path.version>
+    <java.properties.to.json.version>5.0.1</java.properties.to.json.version>
   </properties>
 
   <repositories>
@@ -60,6 +62,18 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-jexl3</artifactId>
       <version>${commons-jexl3.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <version>${json.path.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>pl.jalokim.propertiestojson</groupId>
+      <artifactId>java-properties-to-json</artifactId>
+      <version>${java.properties.to.json.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/serverless/workflow/api/InitializingContext.java
+++ b/src/main/java/org/serverless/workflow/api/InitializingContext.java
@@ -1,0 +1,80 @@
+/*
+ *
+ *   Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.serverless.workflow.api;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Properties;
+
+import pl.jalokim.propertiestojson.util.PropertiesToJsonConverter;
+
+public class InitializingContext {
+
+    private String context;
+    private String workflowName;
+
+    public String getContext() {
+        return context;
+    }
+
+    public String getWorkflowName() {
+        return workflowName;
+    }
+
+    public void setContext(String context) {
+        this.context = context;
+    }
+
+    public void setWorkflowName(String workflowName) {
+        this.workflowName = workflowName;
+    }
+
+    public void setContext(Map<String, String> context) {
+        this.context = new PropertiesToJsonConverter().convertToJson(context);
+    }
+
+    public void setContext(Map<String, String> context,
+                           String workflowName) {
+        this.context = new PropertiesToJsonConverter().convertToJson(context,
+                                                                     workflowName);
+        this.workflowName = workflowName;
+    }
+
+    public void setContext(Properties properties) {
+        this.context = new PropertiesToJsonConverter().convertToJson(properties);
+    }
+
+    public void setContext(Properties properties,
+                           String workflowName) {
+        this.context = new PropertiesToJsonConverter().convertToJson(properties,
+                                                                     workflowName);
+        this.workflowName = workflowName;
+    }
+
+    public void setContext(InputStream inputStream) {
+        this.context = new PropertiesToJsonConverter().convertToJson(inputStream);
+    }
+
+    public void setContext(InputStream inputStream,
+                           String workflowName) {
+        this.context = new PropertiesToJsonConverter().convertToJson(inputStream,
+                                                                     workflowName);
+        this.workflowName = workflowName;
+    }
+}

--- a/src/main/java/org/serverless/workflow/api/deserializers/DefaultChoiceOperatorDeserializer.java
+++ b/src/main/java/org/serverless/workflow/api/deserializers/DefaultChoiceOperatorDeserializer.java
@@ -1,0 +1,78 @@
+/*
+ *
+ *   Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.serverless.workflow.api.deserializers;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import org.serverless.workflow.api.InitializingContext;
+import org.serverless.workflow.api.choices.DefaultChoice;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultChoiceOperatorDeserializer extends StdDeserializer<DefaultChoice.Operator> {
+
+    private InitializingContext context;
+    private static Logger logger = LoggerFactory.getLogger(DefaultChoiceOperatorDeserializer.class);
+
+    public DefaultChoiceOperatorDeserializer() {
+        this(DefaultChoice.Operator.class);
+    }
+
+    public DefaultChoiceOperatorDeserializer(InitializingContext context) {
+        this(DefaultChoice.Operator.class);
+        this.context = context;
+    }
+
+    public DefaultChoiceOperatorDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public DefaultChoice.Operator deserialize(JsonParser jp,
+                                              DeserializationContext ctxt) throws IOException {
+
+        String value = jp.getText();
+        if (context != null && value.trim().startsWith("$$")) {
+            try {
+                String path = value.substring(1);
+                String result = JsonPath.using(Configuration.defaultConfiguration())
+                        .parse(context.getContext())
+                        .read(path);
+
+                if (result != null) {
+                    return DefaultChoice.Operator.fromValue(result);
+                } else {
+                    logger.warn("Unable to evaluate json path: " + path);
+                    return DefaultChoice.Operator.fromValue(jp.getText());
+                }
+            } catch (Exception e) {
+                logger.info("Exception trying to evaluate json path: " + e.getMessage());
+                return DefaultChoice.Operator.fromValue(jp.getText());
+            }
+        } else {
+            return DefaultChoice.Operator.fromValue(jp.getText());
+        }
+    }
+}
+

--- a/src/main/java/org/serverless/workflow/api/deserializers/DefaultStateTypeDeserializer.java
+++ b/src/main/java/org/serverless/workflow/api/deserializers/DefaultStateTypeDeserializer.java
@@ -1,0 +1,78 @@
+/*
+ *
+ *   Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.serverless.workflow.api.deserializers;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import org.serverless.workflow.api.InitializingContext;
+import org.serverless.workflow.api.states.DefaultState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultStateTypeDeserializer extends StdDeserializer<DefaultState.Type> {
+
+    private InitializingContext context;
+    private static Logger logger = LoggerFactory.getLogger(DefaultStateTypeDeserializer.class);
+
+    public DefaultStateTypeDeserializer() {
+        this(DefaultState.Type.class);
+    }
+
+    public DefaultStateTypeDeserializer(InitializingContext context) {
+        this(DefaultState.Type.class);
+        this.context = context;
+    }
+
+    public DefaultStateTypeDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public DefaultState.Type deserialize(JsonParser jp,
+                                         DeserializationContext ctxt) throws IOException {
+
+        String value = jp.getText();
+        if (context != null && value.trim().startsWith("$$")) {
+            try {
+                String path = value.substring(1);
+                String result = JsonPath.using(Configuration.defaultConfiguration())
+                        .parse(context.getContext())
+                        .read(path);
+
+                if (result != null) {
+                    return DefaultState.Type.fromValue(result);
+                } else {
+                    logger.warn("Unable to evaluate json path: " + path);
+                    return DefaultState.Type.fromValue(jp.getText());
+                }
+            } catch (Exception e) {
+                logger.info("Exception trying to evaluate json path: " + e.getMessage());
+                return DefaultState.Type.fromValue(jp.getText());
+            }
+        } else {
+            return DefaultState.Type.fromValue(jp.getText());
+        }
+    }
+}
+

--- a/src/main/java/org/serverless/workflow/api/deserializers/EndStateStatusDeserializer.java
+++ b/src/main/java/org/serverless/workflow/api/deserializers/EndStateStatusDeserializer.java
@@ -1,0 +1,79 @@
+/*
+ *
+ *   Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.serverless.workflow.api.deserializers;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import org.serverless.workflow.api.InitializingContext;
+import org.serverless.workflow.api.states.EndState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EndStateStatusDeserializer extends StdDeserializer<EndState.Status> {
+
+    private InitializingContext context;
+    private static Logger logger = LoggerFactory.getLogger(EndStateStatusDeserializer.class);
+
+    public EndStateStatusDeserializer() {
+        this(EndState.Status.class);
+    }
+
+    public EndStateStatusDeserializer(InitializingContext context) {
+        this(EndState.Status.class);
+        this.context = context;
+    }
+
+    public EndStateStatusDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public EndState.Status deserialize(JsonParser jp,
+                                       DeserializationContext ctxt) throws IOException {
+
+        String value = jp.getText();
+        if (context != null && value.trim().startsWith("$$")) {
+            try {
+                String path = value.substring(1);
+                String result = JsonPath.using(Configuration.defaultConfiguration())
+                        .parse(context.getContext())
+                        .read(path);
+
+                if (result != null) {
+                    return EndState.Status.fromValue(result);
+                } else {
+                    logger.warn("Unable to evaluate json path: " + path);
+                    return EndState.Status.fromValue(jp.getText());
+                }
+            } catch (Exception e) {
+                logger.info("Exception trying to evaluate json path: " + e.getMessage());
+                return EndState.Status.fromValue(jp.getText());
+            }
+        } else {
+            return EndState.Status.fromValue(jp.getText());
+        }
+    }
+}
+
+

--- a/src/main/java/org/serverless/workflow/api/deserializers/EventActionModeDeserializer.java
+++ b/src/main/java/org/serverless/workflow/api/deserializers/EventActionModeDeserializer.java
@@ -1,0 +1,77 @@
+/*
+ *
+ *   Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.serverless.workflow.api.deserializers;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import org.serverless.workflow.api.InitializingContext;
+import org.serverless.workflow.api.events.Event;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EventActionModeDeserializer extends StdDeserializer<Event.ActionMode> {
+
+    private InitializingContext context;
+    private static Logger logger = LoggerFactory.getLogger(EventActionModeDeserializer.class);
+
+    public EventActionModeDeserializer() {
+        this(Event.ActionMode.class);
+    }
+
+    public EventActionModeDeserializer(InitializingContext context) {
+        this(Event.ActionMode.class);
+        this.context = context;
+    }
+
+    public EventActionModeDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public Event.ActionMode deserialize(JsonParser jp,
+                                        DeserializationContext ctxt) throws IOException {
+
+        String value = jp.getText();
+        if (context != null && value.trim().startsWith("$$")) {
+            try {
+                String path = value.substring(1);
+                String result = JsonPath.using(Configuration.defaultConfiguration())
+                        .parse(context.getContext())
+                        .read(path);
+
+                if (result != null) {
+                    return Event.ActionMode.fromValue(result);
+                } else {
+                    logger.warn("Unable to evaluate json path: " + path);
+                    return Event.ActionMode.fromValue(jp.getText());
+                }
+            } catch (Exception e) {
+                logger.info("Exception trying to evaluate json path: " + e.getMessage());
+                return Event.ActionMode.fromValue(jp.getText());
+            }
+        } else {
+            return Event.ActionMode.fromValue(jp.getText());
+        }
+    }
+}

--- a/src/main/java/org/serverless/workflow/api/deserializers/OperationStateActionModeDeserializer.java
+++ b/src/main/java/org/serverless/workflow/api/deserializers/OperationStateActionModeDeserializer.java
@@ -1,0 +1,78 @@
+/*
+ *
+ *   Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.serverless.workflow.api.deserializers;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import org.serverless.workflow.api.InitializingContext;
+import org.serverless.workflow.api.states.OperationState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OperationStateActionModeDeserializer extends StdDeserializer<OperationState.ActionMode> {
+
+    private InitializingContext context;
+    private static Logger logger = LoggerFactory.getLogger(OperationStateActionModeDeserializer.class);
+
+    public OperationStateActionModeDeserializer() {
+        this(OperationState.ActionMode.class);
+    }
+
+    public OperationStateActionModeDeserializer(InitializingContext context) {
+        this(OperationState.ActionMode.class);
+        this.context = context;
+    }
+
+    public OperationStateActionModeDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public OperationState.ActionMode deserialize(JsonParser jp,
+                                                 DeserializationContext ctxt) throws IOException {
+
+        String value = jp.getText();
+        if (context != null && value.trim().startsWith("$$")) {
+            try {
+                String path = value.substring(1);
+                String result = JsonPath.using(Configuration.defaultConfiguration())
+                        .parse(context.getContext())
+                        .read(path);
+
+                if (result != null) {
+                    return OperationState.ActionMode.fromValue(result);
+                } else {
+                    logger.warn("Unable to evaluate json path: " + path);
+                    return OperationState.ActionMode.fromValue(jp.getText());
+                }
+            } catch (Exception e) {
+                logger.info("Exception trying to evaluate json path: " + e.getMessage());
+                return OperationState.ActionMode.fromValue(jp.getText());
+            }
+        } else {
+            return OperationState.ActionMode.fromValue(jp.getText());
+        }
+    }
+}
+

--- a/src/main/java/org/serverless/workflow/api/deserializers/StringValueDeserializer.java
+++ b/src/main/java/org/serverless/workflow/api/deserializers/StringValueDeserializer.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *   Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.serverless.workflow.api.deserializers;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import org.serverless.workflow.api.InitializingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StringValueDeserializer extends StdDeserializer<String> {
+
+    private InitializingContext context;
+    private static Logger logger = LoggerFactory.getLogger(StringValueDeserializer.class);
+
+    public StringValueDeserializer() {
+        this(String.class);
+    }
+
+    public StringValueDeserializer(InitializingContext context) {
+        this(String.class);
+        this.context = context;
+    }
+
+    public StringValueDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public String deserialize(JsonParser jp,
+                              DeserializationContext ctxt) throws IOException {
+
+        String value = jp.getText();
+        if (context != null && value.trim().startsWith("$$")) {
+            try {
+                String path = value.substring(1);
+                String result = JsonPath.using(Configuration.defaultConfiguration())
+                        .parse(context.getContext())
+                        .read(path);
+
+                if (result != null) {
+                    return result;
+                } else {
+                    logger.warn("Unable to evaluate json path: " + path);
+                    return jp.getText();
+                }
+            } catch (Exception e) {
+                logger.info("Exception trying to evaluate json path: " + e.getMessage());
+                return jp.getText();
+            }
+        } else {
+            return jp.getText();
+        }
+    }
+}

--- a/src/main/java/org/serverless/workflow/api/mapper/WorkflowObjectMapper.java
+++ b/src/main/java/org/serverless/workflow/api/mapper/WorkflowObjectMapper.java
@@ -21,8 +21,17 @@ package org.serverless.workflow.api.mapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.serverless.workflow.api.InitializingContext;
+import org.serverless.workflow.api.choices.DefaultChoice;
 import org.serverless.workflow.api.deserializers.ChoiceDeserializer;
+import org.serverless.workflow.api.deserializers.DefaultChoiceOperatorDeserializer;
+import org.serverless.workflow.api.deserializers.DefaultStateTypeDeserializer;
+import org.serverless.workflow.api.deserializers.EndStateStatusDeserializer;
+import org.serverless.workflow.api.deserializers.EventActionModeDeserializer;
+import org.serverless.workflow.api.deserializers.OperationStateActionModeDeserializer;
 import org.serverless.workflow.api.deserializers.StateDeserializer;
+import org.serverless.workflow.api.deserializers.StringValueDeserializer;
+import org.serverless.workflow.api.events.Event;
 import org.serverless.workflow.api.interfaces.Choice;
 import org.serverless.workflow.api.interfaces.State;
 import org.serverless.workflow.api.serializers.DelayStateSerializer;
@@ -33,10 +42,21 @@ import org.serverless.workflow.api.serializers.ParallelStateSerializer;
 import org.serverless.workflow.api.serializers.SwitchStateSerializer;
 import org.serverless.workflow.api.serializers.TriggerEventSerializer;
 import org.serverless.workflow.api.serializers.WorkflowSerializer;
+import org.serverless.workflow.api.states.DefaultState;
+import org.serverless.workflow.api.states.DelayState;
+import org.serverless.workflow.api.states.EndState;
+import org.serverless.workflow.api.states.EventState;
+import org.serverless.workflow.api.states.OperationState;
+import org.serverless.workflow.api.states.ParallelState;
+import org.serverless.workflow.api.states.SwitchState;
 
 public class WorkflowObjectMapper extends ObjectMapper {
 
     public WorkflowObjectMapper() {
+        this(null);
+    }
+
+    public WorkflowObjectMapper(InitializingContext context) {
         super();
         configure(SerializationFeature.INDENT_OUTPUT,
                   true);
@@ -54,9 +74,33 @@ public class WorkflowObjectMapper extends ObjectMapper {
 
         // deserializers
         module.addDeserializer(State.class,
-                               new StateDeserializer());
+                               new StateDeserializer(context));
         module.addDeserializer(Choice.class,
                                new ChoiceDeserializer());
+        module.addDeserializer(String.class,
+                               new StringValueDeserializer(context));
+        module.addDeserializer(Event.ActionMode.class,
+                               new EventActionModeDeserializer(context));
+        module.addDeserializer(OperationState.ActionMode.class,
+                               new OperationStateActionModeDeserializer(context));
+        module.addDeserializer(EndState.Status.class,
+                               new EndStateStatusDeserializer(context));
+        module.addDeserializer(DefaultState.Type.class,
+                               new DefaultStateTypeDeserializer(context));
+        module.addDeserializer(DelayState.Type.class,
+                               new DefaultStateTypeDeserializer(context));
+        module.addDeserializer(EndState.Type.class,
+                               new DefaultStateTypeDeserializer(context));
+        module.addDeserializer(EventState.Type.class,
+                               new DefaultStateTypeDeserializer(context));
+        module.addDeserializer(OperationState.Type.class,
+                               new DefaultStateTypeDeserializer(context));
+        module.addDeserializer(ParallelState.Type.class,
+                               new DefaultStateTypeDeserializer(context));
+        module.addDeserializer(SwitchState.Type.class,
+                               new DefaultStateTypeDeserializer(context));
+        module.addDeserializer(DefaultChoice.Operator.class,
+                               new DefaultChoiceOperatorDeserializer(context));
 
         registerModule(module);
     }

--- a/src/test/java/org/serverless/workflow/api/ObjectMapperTest.java
+++ b/src/test/java/org/serverless/workflow/api/ObjectMapperTest.java
@@ -18,52 +18,300 @@
 
 package org.serverless.workflow.api;
 
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.serverless.workflow.api.mapper.WorkflowObjectMapper;
+import org.serverless.workflow.api.states.EndState;
+import org.serverless.workflow.api.utils.TestUtils;
 
 public class ObjectMapperTest {
 
+    private static final String testEndState = "{\n" +
+            "  \"name\": \"test-wf\",\n" +
+            "  \"states\": [\n" +
+            "    {\n" +
+            "      \"status\": \"SUCCESS\",\n" +
+            "      \"name\": \"test-state\",\n" +
+            "      \"type\": \"END\",\n" +
+            "      \"start\": false\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+
+    private static final String testEndStateForInitializingContext = "{\n" +
+            "  \"name\": \"$$.defaults.wfname\",\n" +
+            "  \"states\": [\n" +
+            "    {\n" +
+            "      \"status\": \"SUCCESS\",\n" +
+            "      \"name\": \"$$.defaults.endstate.name\",\n" +
+            "      \"type\": \"END\",\n" +
+            "      \"start\": false\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+
     @Test
     public void testReadTreeToJson() throws Exception {
-        WorkflowObjectMapper mapper = new WorkflowObjectMapper();
+        WorkflowObjectMapper mapper = new WorkflowObjectMapper(null);
 
-        JsonNode node = mapper.readTree("{\n" +
-                                                "  \"name\": \"test-wf\",\n" +
-                                                "  \"states\": [\n" +
-                                                "    {\n" +
-                                                "      \"status\": \"SUCCESS\",\n" +
-                                                "      \"name\": \"test-state\",\n" +
-                                                "      \"type\": \"END\",\n" +
-                                                "      \"start\": false\n" +
-                                                "    }\n" +
-                                                "  ]\n" +
-                                                "}");
+        JsonNode node = mapper.readTree(testEndState);
         Assertions.assertNotNull(node);
         Assertions.assertEquals("test-wf",
                                 node.get("name").textValue());
+        Assertions.assertEquals("test-state",
+                                node.get("states").get(0).get("name").textValue());
+        Assertions.assertEquals("test-state",
+                                node.get("states").get(0).get("name").textValue());
+        Assertions.assertEquals("SUCCESS",
+                                node.get("states").get(0).get("status").textValue());
     }
 
     @Test
     public void testReadTreeToWorkflow() throws Exception {
-        WorkflowObjectMapper mapper = new WorkflowObjectMapper();
+        WorkflowObjectMapper mapper = new WorkflowObjectMapper(null);
 
-        Workflow workflow = mapper.readValue("{\n" +
-                                                     "  \"name\": \"test-wf\",\n" +
-                                                     "  \"states\": [\n" +
-                                                     "    {\n" +
-                                                     "      \"status\": \"SUCCESS\",\n" +
-                                                     "      \"name\": \"test-state\",\n" +
-                                                     "      \"type\": \"END\",\n" +
-                                                     "      \"start\": false\n" +
-                                                     "    }\n" +
-                                                     "  ]\n" +
-                                                     "}",
+        Workflow workflow = mapper.readValue(testEndState,
                                              Workflow.class);
 
         Assertions.assertNotNull(workflow);
         Assertions.assertEquals("test-wf",
                                 workflow.getName());
+        Assertions.assertNotNull(workflow.getStates());
+        Assertions.assertEquals(1,
+                                workflow.getStates().size());
+        Assertions.assertTrue(workflow.getStates().get(0) instanceof EndState);
+        EndState endstate = (EndState) workflow.getStates().get(0);
+        Assertions.assertEquals("test-state",
+                                endstate.getName());
+        Assertions.assertEquals(EndState.Status.SUCCESS,
+                                endstate.getStatus());
+    }
+
+    @Test
+    public void testReadTreeToJsonWithStringInitializingContext() throws Exception {
+        WorkflowObjectMapper mapper = new WorkflowObjectMapper(getStringBasedInitializngContext());
+
+        JsonNode node = mapper.readTree(testEndStateForInitializingContext);
+        Workflow workflow = mapper.treeToValue(node,
+                                               Workflow.class);
+
+        Assertions.assertNotNull(workflow);
+
+        Assertions.assertEquals("test-wf",
+                                workflow.getName());
+        Assertions.assertNotNull(workflow.getStates());
+        Assertions.assertEquals(1,
+                                workflow.getStates().size());
+        Assertions.assertTrue(workflow.getStates().get(0) instanceof EndState);
+        EndState endstate = (EndState) workflow.getStates().get(0);
+        Assertions.assertEquals("test-state",
+                                endstate.getName());
+        Assertions.assertEquals(EndState.Status.SUCCESS,
+                                endstate.getStatus());
+    }
+
+    @Test
+    public void testReadTreeToWorkflowWithStringInitializingContext() throws Exception {
+        WorkflowObjectMapper mapper = new WorkflowObjectMapper(getStringBasedInitializngContext());
+
+        Workflow workflow = mapper.readValue(testEndStateForInitializingContext,
+                                             Workflow.class);
+
+        Assertions.assertNotNull(workflow);
+        Assertions.assertEquals("test-wf",
+                                workflow.getName());
+        Assertions.assertNotNull(workflow.getStates());
+        Assertions.assertEquals(1,
+                                workflow.getStates().size());
+        Assertions.assertTrue(workflow.getStates().get(0) instanceof EndState);
+        EndState endstate = (EndState) workflow.getStates().get(0);
+        Assertions.assertEquals("test-state",
+                                endstate.getName());
+        Assertions.assertEquals(EndState.Status.SUCCESS,
+                                endstate.getStatus());
+    }
+
+    @Test
+    public void testReadTreeToJsonWithMapInitializingContext() throws Exception {
+        WorkflowObjectMapper mapper = new WorkflowObjectMapper(getMapBasedInitializingContext());
+
+        JsonNode node = mapper.readTree(testEndStateForInitializingContext);
+        Workflow workflow = mapper.treeToValue(node,
+                                               Workflow.class);
+
+        Assertions.assertNotNull(workflow);
+
+        Assertions.assertEquals("test-wf",
+                                workflow.getName());
+        Assertions.assertNotNull(workflow.getStates());
+        Assertions.assertEquals(1,
+                                workflow.getStates().size());
+        Assertions.assertTrue(workflow.getStates().get(0) instanceof EndState);
+        EndState endstate = (EndState) workflow.getStates().get(0);
+        Assertions.assertEquals("test-state",
+                                endstate.getName());
+        Assertions.assertEquals(EndState.Status.SUCCESS,
+                                endstate.getStatus());
+    }
+
+    @Test
+    public void testReadTreeToWorkflowWithMapInitializingContext() throws Exception {
+        WorkflowObjectMapper mapper = new WorkflowObjectMapper(getMapBasedInitializingContext());
+
+        Workflow workflow = mapper.readValue(testEndStateForInitializingContext,
+                                             Workflow.class);
+
+        Assertions.assertNotNull(workflow);
+        Assertions.assertEquals("test-wf",
+                                workflow.getName());
+        Assertions.assertNotNull(workflow.getStates());
+        Assertions.assertEquals(1,
+                                workflow.getStates().size());
+        Assertions.assertTrue(workflow.getStates().get(0) instanceof EndState);
+        EndState endstate = (EndState) workflow.getStates().get(0);
+        Assertions.assertEquals("test-state",
+                                endstate.getName());
+        Assertions.assertEquals(EndState.Status.SUCCESS,
+                                endstate.getStatus());
+    }
+
+    @Test
+    public void testReadTreeToJsonWithPropertiesInitializingContext() throws Exception {
+        WorkflowObjectMapper mapper = new WorkflowObjectMapper(getPropertiesBasedIntializationContext());
+
+        JsonNode node = mapper.readTree(testEndStateForInitializingContext);
+        Workflow workflow = mapper.treeToValue(node,
+                                               Workflow.class);
+
+        Assertions.assertNotNull(workflow);
+
+        Assertions.assertEquals("test-wf",
+                                workflow.getName());
+        Assertions.assertNotNull(workflow.getStates());
+        Assertions.assertEquals(1,
+                                workflow.getStates().size());
+        Assertions.assertTrue(workflow.getStates().get(0) instanceof EndState);
+        EndState endstate = (EndState) workflow.getStates().get(0);
+        Assertions.assertEquals("test-state",
+                                endstate.getName());
+        Assertions.assertEquals(EndState.Status.SUCCESS,
+                                endstate.getStatus());
+    }
+
+    @Test
+    public void testReadTreeToWorkflowWithPropertiesInitializingContext() throws Exception {
+        WorkflowObjectMapper mapper = new WorkflowObjectMapper(getPropertiesBasedIntializationContext());
+
+        Workflow workflow = mapper.readValue(testEndStateForInitializingContext,
+                                             Workflow.class);
+
+        Assertions.assertNotNull(workflow);
+        Assertions.assertEquals("test-wf",
+                                workflow.getName());
+        Assertions.assertNotNull(workflow.getStates());
+        Assertions.assertEquals(1,
+                                workflow.getStates().size());
+        Assertions.assertTrue(workflow.getStates().get(0) instanceof EndState);
+        EndState endstate = (EndState) workflow.getStates().get(0);
+        Assertions.assertEquals("test-state",
+                                endstate.getName());
+        Assertions.assertEquals(EndState.Status.SUCCESS,
+                                endstate.getStatus());
+    }
+
+    @Test
+    public void testReadTreeToJsonWithInputStreamInitializingContext() throws Exception {
+        WorkflowObjectMapper mapper = new WorkflowObjectMapper(getInputStreamBasedIntializationContext());
+
+        JsonNode node = mapper.readTree(testEndStateForInitializingContext);
+        Workflow workflow = mapper.treeToValue(node,
+                                               Workflow.class);
+
+        Assertions.assertNotNull(workflow);
+
+        Assertions.assertEquals("test-wf",
+                                workflow.getName());
+        Assertions.assertNotNull(workflow.getStates());
+        Assertions.assertEquals(1,
+                                workflow.getStates().size());
+        Assertions.assertTrue(workflow.getStates().get(0) instanceof EndState);
+        EndState endstate = (EndState) workflow.getStates().get(0);
+        Assertions.assertEquals("test-state",
+                                endstate.getName());
+        Assertions.assertEquals(EndState.Status.SUCCESS,
+                                endstate.getStatus());
+    }
+
+    @Test
+    public void testReadTreeToWorkflowWithInputStreamInitializingContext() throws Exception {
+        WorkflowObjectMapper mapper = new WorkflowObjectMapper(getInputStreamBasedIntializationContext());
+
+        Workflow workflow = mapper.readValue(testEndStateForInitializingContext,
+                                             Workflow.class);
+
+        Assertions.assertNotNull(workflow);
+        Assertions.assertEquals("test-wf",
+                                workflow.getName());
+        Assertions.assertNotNull(workflow.getStates());
+        Assertions.assertEquals(1,
+                                workflow.getStates().size());
+        Assertions.assertTrue(workflow.getStates().get(0) instanceof EndState);
+        EndState endstate = (EndState) workflow.getStates().get(0);
+        Assertions.assertEquals("test-state",
+                                endstate.getName());
+        Assertions.assertEquals(EndState.Status.SUCCESS,
+                                endstate.getStatus());
+    }
+
+    private InitializingContext getStringBasedInitializngContext() {
+        InitializingContext context = new InitializingContext();
+        context.setContext("{  \n" +
+                                   "   \"defaults\":{  \n" +
+                                   "      \"wfname\":\"test-wf\",\n" +
+                                   "      \"endstate\":{  \n" +
+                                   "         \"name\":\"test-state\"\n" +
+                                   "      }\n" +
+                                   "   }\n" +
+                                   "}");
+
+        return context;
+    }
+
+    private InitializingContext getMapBasedInitializingContext() {
+        InitializingContext context = new InitializingContext();
+        Map<String, String> propMap = new HashMap<>();
+        propMap.put("defaults.wfname",
+                    "test-wf");
+        propMap.put("defaults.endstate.name",
+                    "test-state");
+        context.setContext(propMap);
+
+        return context;
+    }
+
+    private InitializingContext getPropertiesBasedIntializationContext() {
+        InitializingContext context = new InitializingContext();
+        Properties properties = new Properties();
+        properties.put("defaults.wfname",
+                       "test-wf");
+        properties.put("defaults.endstate.name",
+                       "test-state");
+        context.setContext(properties);
+
+        return context;
+    }
+
+    private InitializingContext getInputStreamBasedIntializationContext() throws Exception {
+        Path appPropertiesPath = TestUtils.getResourcePath("application.properties");
+        InitializingContext context = new InitializingContext();
+        context.setContext(TestUtils.getInputStreamFromPath(appPropertiesPath));
+
+        return context;
     }
 }

--- a/src/test/java/org/serverless/workflow/api/utils/TestUtils.java
+++ b/src/test/java/org/serverless/workflow/api/utils/TestUtils.java
@@ -1,0 +1,41 @@
+/*
+ *
+ *   Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.serverless.workflow.api.utils;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class TestUtils {
+
+    private static final Path resourceDirectory = Paths.get("src",
+                                                            "test",
+                                                            "resources");
+    private static final String absolutePath = resourceDirectory.toFile().getAbsolutePath();
+
+    public static Path getResourcePath(String file) {
+        return Paths.get(absolutePath + File.separator + file);
+    }
+
+    public static InputStream getInputStreamFromPath(Path path) throws Exception {
+        return Files.newInputStream(path);
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+defaults.wfname=test-wf
+defaults.endstate.name=test-state


### PR DESCRIPTION
This provides ability to set up initializing context (string, map, Properties object, properties file)
where default values can be provided for string and enum values inside the workflow json/yaml.

For example if we had application.properties defined in our app with lets say:

```
my.workflow.default.name=defaultName
```

then in our workflow we can specify lets say (json path expression):

```json
{
    "name": "$$.my.workflow.default.name",
    "states": []
}
```

When the Workflow instance is created, the json path expression will be evaluated against the given property source.

Note that for initializing context we must specify the start of our jspn path expressions with "$$".
This is so that it does not collide with json path expressions that have to be evaluated at application runtime (this is for initialization only -- when parsing to object model).